### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,15 +3,15 @@ ThinkPHPUnit
 
 在[ThinkPHP](http://www.thinkphp.cn/)开源框架上，使用[PHPUnit](https://github.com/sebastianbergmann/phpunit/)作为测试框架。
 
-##安装和样例代码
+## 安装和样例代码
 
-###安装方法
+### 安装方法
 ```
 shell> cd /path/to/thinkphp/app/Lib/ORG/
 shell> git clone https://github.com/gaoermai/ThinkPHPUnit.git
 ```
 
-###创建TestAction
+### 创建TestAction
 在 **/path/to/thinkphp/app/Lib/Action** 下（如有分组请自行决定放在哪个分组下，或者可以创建一个专门的test分组），创建 **TestAction.class.php** ，代码如下：
     
     import('@.ORG.ThinkPHPUnit.ThinkPHPUnitAction');
@@ -44,9 +44,9 @@ shell> git clone https://github.com/gaoermai/ThinkPHPUnit.git
         METHOD: testExample
         LINE: 12
 
-##使用帮助
+## 使用帮助
 
-###创建测试用例Action
+### 创建测试用例Action
 ThinkPHPUnit需要独立的Action文件，继承ThinkPHPUnitAction类。
 
 类似这样：
@@ -57,7 +57,7 @@ class TestAction extends ThinkPHPUnitAction {}
 类中的方法，只有类似 **public testFuncName()** 或者 **protected _testFuncName()** 这样命名的，才会被认为是包含测试用例的测试方法。 **ThinkPHPUnitAction::index()** 能够自动地逐一执行这些方法并返回结果。
 
 
-###使用哪种断言错误记录方式
+### 使用哪种断言错误记录方式
 
 定义记录错误的方式使用下面代码：
     
@@ -79,7 +79,7 @@ ThinkPHPUnit支持4种断言错误输出常量：
 * 如果有安全屏蔽测试用的Action，那么仍然可以采用 **ThinkPHPUnitAction::MESSAGE_RENDER_ECHO** 方式；
 * 如果没有，那么建议采用 **ThinkPHPUnitAction::MESSAGE_RENDER_ERROR_LOG** 。
 
-###如何测试异常？
+### 如何测试异常？
 
 在[PHPUnit](http://phpunit.de/manual/current/en/writing-tests-for-phpunit.html#writing-tests-for-phpunit.exceptions)的官方文档中，有描述通过类似下面的注释代码来测试异常：
 ```
@@ -108,11 +108,11 @@ class ExceptionTest extends PHPUnit_Framework_TestCase
 ```
 使用这种方法，可以输出预期异常并输出。
 
-###生产环境部署须知
+### 生产环境部署须知
 
 在生产环境中，为了限制普通用户访问测试用例，可以采用以下几种安全措施。
 
-####设置HTTP Authentication
+#### 设置HTTP Authentication
 
 HTTP Authentication是一种HTTP基础的用户名密码验证方式。从ThinkPHPUnit v0.2版本开始，内置了这种验证方式。配置方法：
     
@@ -126,10 +126,10 @@ HTTP Authentication是一种HTTP基础的用户名密码验证方式。从ThinkP
 
 默认的，当常量 **APP_DEBUG** 为true时，HTTP验证不开启。
 
-####采用随机的Action名
+#### 采用随机的Action名
 
 不采用常见的如 **TestAction** 这样的名称，能够有效的避免非法用户猜测测试用例的网址。
 
-####在Web服务器上限定IP等措施
+#### 在Web服务器上限定IP等措施
 
 更加安全的做法，可以在Web服务（如Apache、Nginx）上，对测试用例所在的网址进行IP过滤等。这些方法属于Web服务的讨论范围，请阅读相关文档。


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
